### PR TITLE
Document running with SSH or HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ python3 -m pip install pipx
 python3 -m pipx ensurepath
 pipx install pipenv
 
-# Initialize your project
+# Initialize your project either with HTTP or SSH
+# Uses HTTP
 pipx run cookiecutter gh:seisollc/cookiecutter-python
+# Uses SSH
+pipx run cookiecutter git+ssh://git@github.com/seisollc/cookiecutter-python.git
 
 # Enter the project directory
 cd $(ls -td * | head -1)


### PR DESCRIPTION
# Contributor Comments
Minor documentation update.  I confirmed that `gh:` is `https://` via [this](https://github.com/cookiecutter/cookiecutter/blob/d8672b11e445a918431933c322e7ac96440fd438/cookiecutter/config.py#L15-L16) - you are welcome to trace it on your own.

## Pull Request Checklist
Thank you for submitting a contribution to cookiecutter-python

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:
- [X] Rebase your branch against the latest commit of the target branch
- [X] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)