### PR TITLE
Refactor: Cleanup unneeded pylint exceptions and versioning configs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,5 +14,3 @@ description-file = "README.md"
 license_file = "LICENSE"
 name = "cookiecutter-python"
 url = "https://github.com/SeisoLLC/cookiecutter-python"
-
-[bumpversion:file:setup.cfg]

--- a/tasks.py
+++ b/tasks.py
@@ -32,7 +32,7 @@ REPO = git.Repo(CWD)
 
 # Tasks
 @task
-def test(c):  # pylint: disable=unused-argument
+def test(_c):
     """Test cookiecutter-python"""
     try:
         subprocess.run(
@@ -46,7 +46,7 @@ def test(c):  # pylint: disable=unused-argument
 
 
 @task(pre=[test])
-def release(c):  # pylint: disable=unused-argument
+def release(_c):
     """Make a new release of cookiecutter-python"""
     if REPO.head.is_detached:
         LOG.error("In detached HEAD state, refusing to release")

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -27,5 +27,3 @@ url = "https://github.com/SeisoLLC/{{ cookiecutter.project_slug }}"
 [bumpversion:file:{{ cookiecutter.project_slug }}/__init__.py]
 
 [bumpversion:file:README.md]
-
-[bumpversion:file:setup.cfg]

--- a/{{cookiecutter.project_slug}}/tasks.py
+++ b/{{cookiecutter.project_slug}}/tasks.py
@@ -52,7 +52,7 @@ def process_container(*, container: docker.models.containers.Container) -> None:
 
 # Tasks
 @task
-def lint(c):  # pylint: disable=unused-argument
+def lint(_c):
     """Lint {{ cookiecutter.project_name }}"""
     environment = {}
 
@@ -87,7 +87,7 @@ def lint(c):  # pylint: disable=unused-argument
 
 
 @task
-def build(c):  # pylint: disable=unused-argument
+def build(_c):
     """Build {{ cookiecutter.project_name }}"""
     version_string = "v" + __version__
     commit_hash = REPO.head.commit.hexsha
@@ -114,7 +114,7 @@ def build(c):  # pylint: disable=unused-argument
 
 
 @task(pre=[lint, build])
-def test(c):  # pylint: disable=unused-argument
+def test(_c):
     """Test {{ cookiecutter.project_name }}"""
     try:
         subprocess.run(
@@ -136,7 +136,7 @@ def test(c):  # pylint: disable=unused-argument
 
 
 @task
-def reformat(c):  # pylint: disable=unused-argument
+def reformat(_c):
     """Reformat {{ cookiecutter.project_name }}"""
     entrypoint_and_command = [
         ("isort", ". --settings-file /action/lib/.automation/.isort.cfg"),
@@ -164,9 +164,9 @@ def reformat(c):  # pylint: disable=unused-argument
 
 @task(pre=[test])
 {%- if cookiecutter.versioning == 'SemVer-ish' %}
-def release(c, release_type):  # pylint: disable=unused-argument
+def release(_c, release_type):
 {%- elif cookiecutter.versioning == 'CalVer' %}
-def release(c):  # pylint: disable=unused-argument
+def release(_c):
 {%- endif %}
     """Make a new release of {{ cookiecutter.project_name }}"""
     if REPO.head.is_detached:
@@ -208,7 +208,7 @@ def release(c):  # pylint: disable=unused-argument
 
 
 @task
-def publish(c, tag):  # pylint: disable=unused-argument
+def publish(_c, tag):
     """Publish {{ cookiecutter.project_name }}"""
     if tag not in ["latest", "release"]:
         LOG.error("Please provide a tag of either latest or release")


### PR DESCRIPTION
# Contributor Comments

This is a non-breaking refactor to reduce cruft.  `bumpversion` automatically manages the `setup.cfg` file, per a conversation I had with the maintainers, so specifying it in the `setup.cfg` is unnecessary.  Also, we should reduce `pylint` exceptions as much as possible, which can be worked around by using `_c` instead of `c` in the `task`s

CI is expected to fail for the time being, due to an unrelated issue related to the introduction of `mypy` requirements from `seiso/goat`.  That should be managed separately, and approval of this PR is contingent of passing CI.

## Pull Request Checklist

Thank you for submitting a contribution to cookiecutter-python

In order to streamline the review of your contribution we ask that you review
and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)