### PR TITLE
Improve logging

### DIFF
--- a/{{cookiecutter.project_slug}}/tasks.py
+++ b/{{cookiecutter.project_slug}}/tasks.py
@@ -3,7 +3,6 @@
 Task execution tool & library
 """
 
-import ast
 import os
 {%- if cookiecutter.versioning == 'CalVer' %}
 import re
@@ -49,6 +48,24 @@ def process_container(*, container: docker.models.containers.Container) -> None:
         sys.exit(response["StatusCode"])
     else:
         LOG.info("%s", response["logs"])
+
+
+def log_build_log(*, build_err: docker.errors.BuildError) -> None:
+    """Log the docker build log"""
+    iterator = iter(build_err.build_log)
+    finished = False
+    while not finished:
+        try:
+            item = next(iterator)
+            if "stream" in item:
+                if item["stream"] != "\n":
+                    LOG.error("%s", item["stream"].strip())
+            elif "errorDetail" in item:
+                LOG.error("%s", item["errorDetail"])
+            else:
+                LOG.error("%s", item)
+        except StopIteration:
+            finished = True
 
 
 # Tasks
@@ -121,14 +138,7 @@ def build(_c, debug=False):
             )
         except docker.errors.BuildError as build_err:
             LOG.exception("Failed to build, retrieving and logging the more detailed build error...")
-            iterator = iter(build_err.build_log)
-            finished = False
-            while not finished:
-                try:
-                    item = next(iterator)
-                    LOG.error("%s", ast.literal_eval(item)["stream"])
-                except StopIteration:
-                    finished = True
+            log_build_log(build_err=build_err)
             sys.exit(1)
 
 


### PR DESCRIPTION
# Contributor Comments

This improves the docker build log logging.

## Testing

Break the docker build (echo 'RUN apt-get notavalidsubcommand' >> Dockerfile) and re-run pipenv run invoke build, and observe lengthy logs detailing the build process and the docker build errors, but with no extraneous newlines or messy nested dicts.

## Pull Request Checklist

Thank you for submitting a contribution to cookiecutter-python

In order to streamline the review of your contribution we ask that you review
and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)