### PR TITLE
fix: re-add linting and building to tests

### DIFF
--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -160,7 +160,7 @@ def test_default_project(cookies):
 
     try:
         subprocess.run(
-            ["pipenv", "run", "invoke", "test"],
+            ["pipenv", "run", "invoke", "lint", "build", "test"],
             capture_output=True,
             check=True,
             cwd=project,


### PR DESCRIPTION
# Contributor Comments

In #39 we decoupled testing from linting and building, but did not add linting and building into the `cookiecutter-python` tests.  This adds that back in.

## Pull Request Checklist

Thank you for submitting a contribution to cookiecutter-python

In order to streamline the review of your contribution we ask that you review
and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)