### PR TITLE
Limit GitHub Actions permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   distribute:
     name: Distribute
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,6 +9,8 @@ jobs:
   update:
     name: Update
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
   distribute:
     name: Distribute
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2

--- a/{{cookiecutter.project_slug}}/.github/workflows/update.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/update.yml
@@ -9,6 +9,8 @@ jobs:
   update:
     name: Update
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2


### PR DESCRIPTION
# Contributor Comments

Limit GitHub Actions permissions; this allow us to have a `GITHUB_TOKEN` left at Read by default.  See the docs [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).

## Pull Request Checklist

Thank you for submitting a contribution to cookiecutter-python

In order to streamline the review of your contribution we ask that you review
and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, link the issue to the PR.