### PR TITLE
Removing refurb from 3.9 projects

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -18,7 +18,7 @@ pylint = "*"
 pytest = "*"
 pytest-cov = "*"
 pytest-mock = "*"
-{%- if cookiecutter.python_version == '3.10' or cookiecutter.python_version == '3.10' %}
+{%- if cookiecutter.python_version != '3.9' %}
 refurb = "*"
 {%- endif %}
 


### PR DESCRIPTION
# Contributor Comments

Removing refurb from projects generated for Python 3.9 as it is not supported for Python versions previous to 3.10.

## Pull Request Checklist

Thank you for submitting a contribution to cookiecutter-python!

In order to streamline the review of your contribution we ask that you review
and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch.
- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.
