### PR TITLE
fix: auto update PR workflows

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3

--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/update.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/update.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3


### PR DESCRIPTION
# Contributor Comments

Previously we forgot to add the permission to open PRs to the GITHUB_TOKEN for the generated and parent project, so the auto update PRs weren't authorized to open the PRs.

## Pull Request Checklist

Thank you for submitting a contribution to cookiecutter-python!

In order to streamline the review of your contribution we ask that you review
and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch.
- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.
