### PR TITLE
feat: generate a more robust dictionary for hyphenated projects

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -118,6 +118,21 @@ def run_post_gen_hook():
         if "{{ cookiecutter.versioning }}" == "CalVer":
             release_github_action: Path = Path("./.github/workflows/release.yml")
             release_github_action.unlink()
+
+        # Sort and unique the generated dictionary.txt file
+        dictionary: Path = Path("./.github/etc/dictionary.txt")
+        sorted_uniqued_dictionary: list[str] = sorted(
+            set(dictionary.read_text("utf-8").split("\n"))
+        )
+
+        if "" in sorted_uniqued_dictionary:
+            sorted_uniqued_dictionary.remove("")
+
+        dictionary.write_text(
+            "\n".join(sorted_uniqued_dictionary),
+            encoding="utf-8",
+        )
+
         subprocess.run(
             ["git", "init", "--initial-branch=main"], capture_output=True, check=True
         )

--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/etc/dictionary.txt
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/etc/dictionary.txt
@@ -1,1 +1,4 @@
-{{cookiecutter.project_slug}}
+{%- set fragments = cookiecutter.project_slug.split('_') -%}
+{%- for item in fragments -%}
+{{ item }}
+{% endfor -%}


### PR DESCRIPTION
# Contributor Comments

Previously if you have a project like jargon_and_things and 'jargon' was not in the global dictionaries, after generation it would fail the dictionary check by the goat.  This fixes that

## Pull Request Checklist

Thank you for submitting a contribution to cookiecutter-python!

In order to streamline the review of your contribution we ask that you review
and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch.
- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.
