### PR TITLE
test: run sbom and vulnscan tests regardless of platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,14 @@ jobs:
           path: ~/.local/share/virtualenvs
           key: ${{ runner.os }}-python-${{ env.python_version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
       - name: Install the dependencies
-        run: python -m pip install --upgrade pipenv
+        run: |
+          python -m pip install --upgrade pipenv
+          mkdir "${RUNNER_TEMP}/bin"
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b "${RUNNER_TEMP}/bin"
+          chmod +x "${RUNNER_TEMP}/bin/syft"
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b "${RUNNER_TEMP}/bin"
+          chmod +x "${RUNNER_TEMP}/bin/grype"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
       - name: Install Task
         uses: arduino/setup-task@v1
       - name: Initialize the repo
@@ -89,9 +96,6 @@ jobs:
         with:
           path: ~/.local/share/virtualenvs
           key: ${{ runner.os }}-python-${{ env.python_version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-python-${{ env.python_version }}-pipenv-
-            ${{ runner.os }}-python-
       - name: Install the dependencies
         run: python -m pip install --upgrade pipenv
       - name: Install Task

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -171,9 +171,18 @@ def test_default_project(cookies):
         # Build and test all supported architectures
         env = os.environ.copy()
         env["PLATFORM"] = "all"
-        # We don't test sbom or vulnscan here because multiplatform builds aren't loaded into the local docker daemon
         subprocess.run(
-            ["task", "init", "lint", "validate", "build", "test"],
+            [
+                "task",
+                "-v",
+                "init",
+                "lint",
+                "validate",
+                "build",
+                "test",
+                "sbom",
+                "vulnscan",
+            ],
             capture_output=True,
             check=True,
             cwd=project,
@@ -184,27 +193,17 @@ def test_default_project(cookies):
         for platform in ("linux/arm64", "linux/amd64"):
             env["PLATFORM"] = platform
             subprocess.run(
-                ["task", "build", "test"],
+                ["task", "-v", "build", "test", "sbom", "vulnscan"],
                 capture_output=True,
                 check=True,
                 cwd=project,
                 env=env,
             )
 
-            # This is because only the build for the local platform is loaded into the docker daemon
-            if platform == LOCAL_PLATFORM:
-                subprocess.run(
-                    ["task", "sbom", "vulnscan"],
-                    capture_output=True,
-                    check=True,
-                    cwd=project,
-                    env=env,
-                )
-
         # Do two releases to ensure they work
         for _ in range(2):
             subprocess.run(
-                ["task", "release"],
+                ["task", "-v", "release"],
                 capture_output=True,
                 check=True,
                 cwd=project,


### PR DESCRIPTION
# Contributor Comments

In SeisoLLC/goat@2cb21769010f4701a52e5b26eee07f6e7603b20e we added multiplatform sbom and vulnscan support; it should be tested here as well.

## Pull Request Checklist

Thank you for submitting a contribution to cookiecutter-python!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).
