### PR TITLE
Fix datetime deprecation

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -36,7 +36,7 @@ PROJECT_CONTEXT = Path(".github/project.yml")
 def get_context() -> dict:
     """Return the context as a dict"""
     cookiecutter = None
-    timestamp = datetime.datetime.utcnow().isoformat(timespec="seconds")
+    timestamp = datetime.datetime.now(datetime.UTC).isoformat(timespec="seconds")
 
     ##############
     # This section leverages cookiecutter's jinja interpolation

--- a/{{cookiecutter.project_name|replace(" ", "")}}/CONTRIBUTING.md
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/CONTRIBUTING.md
@@ -29,6 +29,6 @@ task update
 task release minor # or major, or patch
 
 # Push it!  (Subject to branch policies)
-git push --atomic origin $(git branch --show-current) $(git describe --tags)
+git push --atomic origin $(git branch --show-current) --follow-tags
 ```
 {%- endif %}


### PR DESCRIPTION
# Contributor Comments

This fixes a `datetime` deprecation.

On creation of new repos with `cookiecutter-python` we have recently started getting:

> /var/folders/0z/bsq8pvz92rx6sxjh_h5d95fw0000gn/T/tmp7sh1faqb.py:39: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
>  timestamp = datetime.datetime.utcnow().isoformat(timespec="seconds")

## Pull Request Checklist

Thank you for submitting a contribution to cookiecutter-python!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).
